### PR TITLE
Use session id from arguments in rake task 'scrape_session'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ end
 desc "Scrape Documents of Session with session_id"
 task :scrape_session, :session_id do |t, args|
   session_path = File.join(DOWNLOAD_PATH, args.session_id)
-  session_url = sprintf(SESSION_URI, session_id)
+  session_url = sprintf(SESSION_URI, args.session_id)
   Scrape.scrape_session(session_url, session_path)
 end
 


### PR DESCRIPTION
Without this change I wasn't able to execute the scraper with a particular session id like this:

```
rake scrape_session[2632]
```
